### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules
 *~
 docs/annotated
 docs/coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,42 +1,17 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js][] transport plugin for Redis
+> A [Seneca.js][] plugin
 
-# seneca-redis-pubsub-transport
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
+# @seneca/redis-pubsub-transport
 
-[![js-standard-style][standard-badge]][standard-style]
-
-A transport module that uses [redis] as it's engine. It may also be used as an example on how to implement a transport plugin for Seneca.
-
-__Note:__ This is broadcast transport. All subscribed micro-services receive all messages.
-
-If you are new to Seneca in general, please take a look at [senecajs.org][]. We have everything from
-tutorials to sample apps to help get you up and running quickly.
-
-If you're using this module, and need help, you can:
-
-- Post a [github issue][],
-- Tweet to [@senecajs][],
-- Ask on the [Gitter][gitter-url].
-
-### Seneca compatibility
-Supports Seneca versions **1.x** - **3.x**
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
-To install, simply use npm. Remember you will need to install [Seneca.js][] if you haven't already.
 
 ```sh
-
 npm install seneca --save
 npm install seneca-redis-pubsub-transport --save
-
 ```
-
-In order to use this transport, you need to have a [redis][] daemon running. The deamon and instructions on how to install can be found on the redis [install page][].
 
 ## Quick Example
 
@@ -49,39 +24,57 @@ require('seneca')()
   .listen({type:'redis'}) // add listen to be able this micro-service to subscribe
 ```
 
-## Running Examples
+## More Examples
 
-In order to run the [examples][] we provide the required docker configuration
-in `docker-compose.yml` and the folder `docker`. Just run `docker-compose up` in
-the root folder and it should bring up a redis server. Please be aware that if you
-are using `docker-machine` the ip running the redis server is the ip of your docker-machine.
+See [test/](test/) for usage examples.
 
-In order to find the ip of your `docker-machine` just execute:
-```
-docker-machine ip <your-docker-machine-name>
-```
+## Motivation
 
-## Example Using Redis Server Url
+A transport module that uses [redis][] as its engine. This is a broadcast transport — all subscribed micro-services receive all messages.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+- Ask on the [Gitter][gitter-url]
+
+## API
+
+### Example Using Redis Server URL
+
 ```js
 require('seneca')({
   transport: {
     redis: {
-      // you can use The URL of the Redis server. Format:-
-      url: "[redis:]//[[user][:password@]][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]]"
+      url: "[redis:]//[[user][:password@]][host][:port][/db-number]"
     }
   }
 })
 .use('seneca-redis-transport')
 ```
-(More info available About Url Format at [IANAl] ).
 
 ## Contributing
-The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with
-documentation, examples, extra testing, or new features please get in touch.
 
-## License
-Copyright Richard Rodger and other contributors 2014 - 2016, Licensed under [MIT][].
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
+### Running examples with Docker
+
+```sh
+docker-compose up
+```
+
+## Background
+
+Uses [redis](http://redis.io/) for pub-sub message distribution. See [examples](https://github.com/senecajs/seneca-redis-pubsub-transport/tree/master/docs/examples) for more.
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Coverage Status][coveralls-badge]][coveralls-url]
+[![Dependency Status][david-badge]][david-url]
+[![Gitter][gitter-badge]][gitter-url]
+[![js-standard-style][standard-badge]][standard-style]
 [npm-badge]: https://img.shields.io/npm/v/seneca-redis-pubsub-transport.svg
 [npm-url]: https://npmjs.com/package/seneca-redis-pubsub-transport
 [travis-badge]: https://api.travis-ci.org/senecajs/seneca-redis-pubsub-transport.svg
@@ -92,10 +85,8 @@ Copyright Richard Rodger and other contributors 2014 - 2016, Licensed under [MIT
 [david-url]: https://david-dm.org/senecajs/seneca-redis-pubsub-transport
 [gitter-badge]: https://badges.gitter.im/senecajs/seneca.svg
 [gitter-url]: https://gitter.im/senecajs/seneca
-
 [standard-badge]: https://raw.githubusercontent.com/feross/standard/master/badge.png
 [standard-style]: https://github.com/feross/standard
-
 [redis]: http://redis.io/
 [install page]: http://redis.io/download
 [MIT]: ./LICENSE
@@ -105,5 +96,4 @@ Copyright Richard Rodger and other contributors 2014 - 2016, Licensed under [MIT
 [github issue]: https://github.com/senecajs/seneca-redis-pubsub-transport/issues
 [examples]: https://github.com/senecajs/seneca-redis-pubsub-transport/tree/master/docs/examples
 [@senecajs]: http://twitter.com/senecajs
-
 [IANAl]: http://www.iana.org/assignments/uri-schemes/prov/redis

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-redis-transport",
+  "name": "@seneca/redis-pubsub-transport",
   "version": "0.3.0",
   "description": "Seneca Redis transport",
   "main": "lib/index.js",
@@ -31,7 +31,7 @@
     "Adrien Becchis (https://github.com/AdrieanKhisbe)",
     "Dean McDonnell (https://github.com/mcdonnelldean)",
     "Emer Rutherford (https://github.com/eeswr)",
-    "Oisín Hennessy (https://github.com/code-jace)",
+    "Ois\u00edn Hennessy (https://github.com/code-jace)",
     "Luca Lanziani (https://github.com/LucaLanziani)",
     "Maxence Dalmais (https://github.com/maxired)",
     "Pierre-Jean Leger (https://github.com/Caligone)",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`